### PR TITLE
Add LICENSE to POD

### DIFF
--- a/lib/Mojolicious/Plugin/Toto.pm
+++ b/lib/Mojolicious/Plugin/Toto.pm
@@ -210,6 +210,11 @@ Document the autcomplete API.
 
 Brian Duggan C<bduggan@matatu.org>
 
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
 =cut
 
 package Mojolicious::Plugin::Toto;


### PR DESCRIPTION
Although the licence for this dist is specified in Build.PL (as "perl") there was no equivalent notice in the docs. This PR just adds that clause.

Mojolicious::Plugin::Toto is this month's dist for [the CPAN PR Challenge](http://cpan-prc.org/) - thanks for participating.