### PR TITLE
Add minimum perl version to Build.PL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,6 +9,7 @@ my $builder = Module::Build->new(
     dist_version_from   => 'lib/Mojolicious/Plugin/Toto.pm',
     requires            => {
             'Mojolicious' => '3.84',
+			'perl'        => '5.6.0',
         },
     build_requires => {
         'Test::More' => 0,


### PR DESCRIPTION
This specifies 5.6.0 as the minimum perl version required.